### PR TITLE
feat: add jjlu, jjnc, jjsqp, jjbc, jbc, jjw* abbreviations from jj-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ fisher install HotThoughts/jj.fish
 
 | Abbr    | Command              | Abbr    | Command                    |
 | ------- | -------------------- | ------- | -------------------------- |
-| `jjl`   | `jj log`             | `jjst`  | `jj st`                    |
-| `jjll`  | `jj log --limit`     | `jjlr`  | `jj log --revisions`       |
-| `jjd`   | `jj describe`        | `jjdm`  | `jj describe -m`           |
-| `jjn`   | `jj new`             | `jjnm`  | `jj new main`              |
-| `jjnmo` | `jj new main@origin` | `jja`   | `jj abandon`               |
-| `jjr`   | `jj rebase`          | `jjrmo` | `jj rebase -d main@origin` |
-| `jjc`   | `jj commit`          | `jjci`  | `jj commit -i`             |
+| `jjl`   | `jj log`             | `jjst`  | `jj st`                                    |
+| `jjll`  | `jj log --limit`     | `jjlr`  | `jj log --revisions`                       |
+| `jjlu`  | `jj log -r 'remote_branches()..@'` | `jjd` | `jj describe`               |
+| `jjdm`  | `jj describe -m`     | `jjn`   | `jj new`                                   |
+| `jjnm`  | `jj new main`        | `jjnmo` | `jj new main@origin`                       |
+| `jjnc`  | `jj new -m`          | `jja`   | `jj abandon`                               |
+| `jjr`   | `jj rebase`          | `jjrmo` | `jj rebase -d main@origin`                 |
+| `jjc`   | `jj commit`          | `jjci`  | `jj commit -i`                             |
 
 ### Viewing and Comparing
 
@@ -35,9 +36,10 @@ fisher install HotThoughts/jj.fish
 
 | Abbr    | Command        | Abbr   | Command     |
 | ------- | -------------- | ------ | ----------- |
-| `jje`   | `jj edit`      | `jjsq` | `jj squash` |
-| `jjsqi` | `jj squash -i` | `jjsp` | `jj split`  |
-| `jjde`  | `jj diffedit`  | `jjab` | `jj absorb` |
+| `jje`   | `jj edit`               | `jjsq`  | `jj squash`          |
+| `jjsqi` | `jj squash -i`          | `jjsqp` | `jj squash --into @-`|
+| `jjsp`  | `jj split`              | `jjde`  | `jj diffedit`        |
+| `jjab`  | `jj absorb`             |         |                      |
 
 ### Navigation
 
@@ -49,9 +51,9 @@ fisher install HotThoughts/jj.fish
 
 | Abbr   | Command              | Abbr   | Command             |
 | ------ | -------------------- | ------ | ------------------- |
-| `jjb`  | `jj bookmark`        | `jjbl` | `jj bookmark list`  |
-| `jjbs` | `jj bookmark set`    | `jjbt` | `jj bookmark track` |
-| `jjbd` | `jj bookmark delete` |        |                     |
+| `jjb`  | `jj bookmark`        | `jjbl` | `jj bookmark list`   |
+| `jjbs` | `jj bookmark set`    | `jjbt` | `jj bookmark track`  |
+| `jjbd` | `jj bookmark delete` | `jjbc` | `jj bookmark create` |
 
 ### Operations
 
@@ -65,6 +67,13 @@ fisher install HotThoughts/jj.fish
 | Abbr   | Command      | Abbr   | Command      |
 | ------ | ------------ | ------ | ------------ |
 | `jjrs` | `jj resolve` | `jjrt` | `jj restore` |
+
+### Workspaces
+
+| Abbr   | Command                | Abbr   | Command               |
+| ------ | ---------------------- | ------ | --------------------- |
+| `jjw`  | `jj workspace`         | `jjwl` | `jj workspace list`   |
+| `jjwa` | `jj workspace add`     | `jjwf` | `jj workspace forget` |
 
 ### Advanced Operations
 
@@ -82,6 +91,7 @@ fisher install HotThoughts/jj.fish
 | `jd`  | `jj describe -m`           | `jr`  | `jj rebase -d main@origin`|
 | `jc`  | `jj commit`                | `jci` | `jj commit -i`            |
 | `jbt` | `jj bookmark track`        | `jbs` | `jj bookmark set`         |
+| `jbc` | `jj bookmark create`       |       |                           |
 
 ### AI-Powered Commit Messages
 

--- a/functions/abbr.fish
+++ b/functions/abbr.fish
@@ -5,12 +5,14 @@
 abbr --add jjl 'jj log'
 abbr --add jjll 'jj log --limit'
 abbr --add jjlr 'jj log --revisions'
+abbr --add jjlu "jj log -r 'remote_branches()..@'"
 abbr --add jjst 'jj st'
 abbr --add jjd 'jj describe'
 abbr --add --set-cursor='%' -- jjdm 'jj describe -m "%"'
 abbr --add jjn 'jj new'
 abbr --add jjnm 'jj new main'
 abbr --add jjnmo 'jj new main@origin'
+abbr --add --set-cursor='%' -- jjnc 'jj new -m "%"'
 abbr --add jja 'jj abandon'
 abbr --add jjr 'jj rebase'
 abbr --add jjrmo 'jj rebase -d main@origin'
@@ -27,6 +29,7 @@ abbr --add jjev 'jj evolog'
 abbr --add jje 'jj edit'
 abbr --add jjsq 'jj squash'
 abbr --add jjsqi 'jj squash -i'
+abbr --add jjsqp 'jj squash --into @-'
 abbr --add jjsp 'jj split'
 abbr --add jjde 'jj diffedit'
 abbr --add jjab 'jj absorb'
@@ -41,6 +44,7 @@ abbr --add jjbl 'jj bookmark list'
 abbr --add jjbs 'jj bookmark set'
 abbr --add jjbt 'jj bookmark track'
 abbr --add jjbd 'jj bookmark delete'
+abbr --add jjbc 'jj bookmark create'
 
 # Operations
 abbr --add jjop 'jj op'
@@ -50,6 +54,12 @@ abbr --add jju 'jj undo'
 # Conflict resolution
 abbr --add jjrs 'jj resolve'
 abbr --add jjrt 'jj restore'
+
+# Workspaces
+abbr --add jjw 'jj workspace'
+abbr --add jjwl 'jj workspace list'
+abbr --add jjwa 'jj workspace add'
+abbr --add jjwf 'jj workspace forget'
 
 # Advanced operations
 abbr --add jjdu 'jj duplicate'
@@ -67,3 +77,4 @@ abbr --add jc 'jj commit'
 abbr --add jci 'jj commit -i'
 abbr --add jbt 'jj bookmark track'
 abbr --add jbs 'jj bookmark set'
+abbr --add jbc 'jj bookmark create'

--- a/tests/test_abbr.fish
+++ b/tests/test_abbr.fish
@@ -38,12 +38,17 @@ assert_abbr_exists jjnm "'jj new main'"
 assert_abbr_exists jjc "'jj commit'"
 assert_abbr_exists jjci "'jj commit -i'"
 
+# Test new abbreviations
+assert_abbr_exists jjbc "'jj bookmark create'"
+assert_abbr_exists jjsqp "'jj squash --into @-'"
+
 # Test short forms
 assert_abbr_exists jp "'jj git push'"
 assert_abbr_exists jf "'jj git fetch'"
 assert_abbr_exists ji "'jj git init --colocate .'"
 assert_abbr_exists jd "'jj describe -m'"
 assert_abbr_exists jc "'jj commit'"
+assert_abbr_exists jbc "'jj bookmark create'"
 
 echo ""
 echo "Results: $pass_count/$test_count passed, $fail_count failed"


### PR DESCRIPTION
## Summary
Adds 9 new abbreviations derived from jj-skills workflow patterns, covering unpushed-change log viewing, new-with-message, squash-into-parent, bookmark create, and workspace operations.

## Changes
- `jjlu` → `jj log -r 'remote_branches()..@'` — view unpushed changes
- `jjnc` → `jj new -m ""` (cursor-positioned) — mirrors `jjdm` pattern for starting new work
- `jjsqp` → `jj squash --into @-` — explicit squash into parent, completes `jjsq`/`jjsqi` family
- `jjbc` / `jbc` → `jj bookmark create` — completes bookmark CRUD set
- `jjw` / `jjwl` / `jjwa` / `jjwf` → workspace subcommands
- Updates README tables and adds test assertions for new abbreviations

🤖 Generated with [Claude Code](https://claude.com/claude-code)