### PR TITLE
chore: replace fish-indent-check with auto-fix and move hooks to pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,9 @@ repos:
         language: system
         files: \.fish$
 
-      - id: fish-indent-check
-        name: Fish Shell Indent Check
-        entry: fish_indent --check
+      - id: fish-indent-fix
+        name: Fish Shell Indent Fix
+        entry: fish_indent -w
         language: system
         files: \.fish$
 
@@ -38,5 +38,5 @@ repos:
         always_run: true
 
 # Configuration
-default_install_hook_types: [pre-push]
-default_stages: [pre-push]
+default_install_hook_types: [pre-commit]
+default_stages: [pre-commit]


### PR DESCRIPTION
## Summary
Replaces the passive indent check with an auto-fix hook and moves all hooks from pre-push to pre-commit so issues are caught and fixed earlier.

## Changes
- Replaces `fish-indent-check` (`fish_indent --check`) with `fish-indent-fix` (`fish_indent -w`) — bad indentation is now auto-corrected in place instead of just failing
- Changes `default_stages` from `pre-push` to `pre-commit` so syntax, indent, and test hooks run on every commit